### PR TITLE
Add OAuth2 security config

### DIFF
--- a/src/main/java/com/vibevault/cartservice/security/RolesClaimConverter.java
+++ b/src/main/java/com/vibevault/cartservice/security/RolesClaimConverter.java
@@ -1,0 +1,28 @@
+package com.vibevault.cartservice.security;
+
+import org.springframework.core.convert.converter.Converter;
+import org.springframework.lang.Nullable;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.oauth2.jwt.Jwt;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class RolesClaimConverter implements Converter<Jwt, Collection<GrantedAuthority>> {
+    @Nullable
+    @Override
+    public Collection<GrantedAuthority> convert(Jwt jwt) {
+        Object rolesClaim = jwt.getClaim("roles");
+
+        if (!(rolesClaim instanceof List<?> rolesList)) {
+            return Collections.emptyList();
+        }
+
+        return rolesList.stream()
+                .map(role -> new SimpleGrantedAuthority("ROLE_" + role.toString()))
+                .collect(Collectors.toList());
+    }
+}

--- a/src/main/java/com/vibevault/cartservice/security/SecurityConfig.java
+++ b/src/main/java/com/vibevault/cartservice/security/SecurityConfig.java
@@ -1,0 +1,41 @@
+package com.vibevault.cartservice.security;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationConverter;
+import org.springframework.security.web.SecurityFilterChain;
+
+@Configuration
+@EnableWebSecurity
+@EnableMethodSecurity
+public class SecurityConfig {
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        http
+                .csrf(AbstractHttpConfigurer::disable)
+                .sessionManagement(session ->
+                        session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+                .authorizeHttpRequests(auth -> auth
+                        .requestMatchers("/actuator/health/**").permitAll()
+                        .anyRequest().authenticated()
+                )
+                .oauth2ResourceServer(oauth2 -> oauth2
+                        .jwt(jwt -> jwt
+                                .jwtAuthenticationConverter(jwtAuthenticationConverter())
+                        )
+                );
+        return http.build();
+    }
+
+    @Bean
+    public JwtAuthenticationConverter jwtAuthenticationConverter() {
+        JwtAuthenticationConverter converter = new JwtAuthenticationConverter();
+        converter.setJwtGrantedAuthoritiesConverter(new RolesClaimConverter());
+        return converter;
+    }
+}


### PR DESCRIPTION
## Summary
- Add `SecurityConfig` — OAuth2 resource server with stateless sessions
- Add `RolesClaimConverter` — maps JWT `roles` claim to `ROLE_` authorities
- All cart endpoints require authentication (only `/actuator/health/**` is public)

Same pattern as productservice and userservice.

Fixes #2