### PR TITLE
Add Kafka producer for cart events

### DIFF
--- a/src/main/java/com/vibevault/cartservice/constants/KafkaTopics.java
+++ b/src/main/java/com/vibevault/cartservice/constants/KafkaTopics.java
@@ -1,0 +1,8 @@
+package com.vibevault.cartservice.constants;
+
+public final class KafkaTopics {
+    public static final String CART_EVENTS = "cart-events";
+
+    private KafkaTopics() {
+    }
+}

--- a/src/main/java/com/vibevault/cartservice/events/CartEvent.java
+++ b/src/main/java/com/vibevault/cartservice/events/CartEvent.java
@@ -1,0 +1,24 @@
+package com.vibevault.cartservice.events;
+
+import com.vibevault.cartservice.models.CartItem;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class CartEvent {
+    private String eventId;
+    private CartEventType eventType;
+    private String userId;
+    private String productId;
+    private Integer quantity;
+    private List<CartItem> items;
+    private LocalDateTime timestamp;
+}

--- a/src/main/java/com/vibevault/cartservice/events/CartEventType.java
+++ b/src/main/java/com/vibevault/cartservice/events/CartEventType.java
@@ -2,6 +2,7 @@ package com.vibevault.cartservice.events;
 
 public enum CartEventType {
     ITEM_ADDED,
+    ITEM_UPDATED,
     ITEM_REMOVED,
     CART_CLEARED,
     CHECKOUT_INITIATED

--- a/src/main/java/com/vibevault/cartservice/events/CartEventType.java
+++ b/src/main/java/com/vibevault/cartservice/events/CartEventType.java
@@ -1,0 +1,8 @@
+package com.vibevault.cartservice.events;
+
+public enum CartEventType {
+    ITEM_ADDED,
+    ITEM_REMOVED,
+    CART_CLEARED,
+    CHECKOUT_INITIATED
+}

--- a/src/main/java/com/vibevault/cartservice/services/CartEventProducer.java
+++ b/src/main/java/com/vibevault/cartservice/services/CartEventProducer.java
@@ -32,6 +32,17 @@ public class CartEventProducer {
                 .build());
     }
 
+    public void sendItemUpdated(String userId, String productId, int quantity) {
+        send(CartEvent.builder()
+                .eventId(UUID.randomUUID().toString())
+                .eventType(CartEventType.ITEM_UPDATED)
+                .userId(userId)
+                .productId(productId)
+                .quantity(quantity)
+                .timestamp(LocalDateTime.now())
+                .build());
+    }
+
     public void sendItemRemoved(String userId, String productId) {
         send(CartEvent.builder()
                 .eventId(UUID.randomUUID().toString())

--- a/src/main/java/com/vibevault/cartservice/services/CartEventProducer.java
+++ b/src/main/java/com/vibevault/cartservice/services/CartEventProducer.java
@@ -1,0 +1,73 @@
+package com.vibevault.cartservice.services;
+
+import com.vibevault.cartservice.constants.KafkaTopics;
+import com.vibevault.cartservice.events.CartEvent;
+import com.vibevault.cartservice.events.CartEventType;
+import com.vibevault.cartservice.models.Cart;
+import com.vibevault.cartservice.models.CartItem;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class CartEventProducer {
+
+    private final KafkaTemplate<String, CartEvent> kafkaTemplate;
+
+    public void sendItemAdded(String userId, String productId, int quantity) {
+        send(CartEvent.builder()
+                .eventId(UUID.randomUUID().toString())
+                .eventType(CartEventType.ITEM_ADDED)
+                .userId(userId)
+                .productId(productId)
+                .quantity(quantity)
+                .timestamp(LocalDateTime.now())
+                .build());
+    }
+
+    public void sendItemRemoved(String userId, String productId) {
+        send(CartEvent.builder()
+                .eventId(UUID.randomUUID().toString())
+                .eventType(CartEventType.ITEM_REMOVED)
+                .userId(userId)
+                .productId(productId)
+                .timestamp(LocalDateTime.now())
+                .build());
+    }
+
+    public void sendCartCleared(String userId) {
+        send(CartEvent.builder()
+                .eventId(UUID.randomUUID().toString())
+                .eventType(CartEventType.CART_CLEARED)
+                .userId(userId)
+                .timestamp(LocalDateTime.now())
+                .build());
+    }
+
+    public void sendCheckoutInitiated(String userId, List<CartItem> items) {
+        send(CartEvent.builder()
+                .eventId(UUID.randomUUID().toString())
+                .eventType(CartEventType.CHECKOUT_INITIATED)
+                .userId(userId)
+                .items(items)
+                .timestamp(LocalDateTime.now())
+                .build());
+    }
+
+    private void send(CartEvent event) {
+        try {
+            kafkaTemplate.send(KafkaTopics.CART_EVENTS, event.getUserId(), event);
+            log.debug("Cart event sent: {} for user {}", event.getEventType(), event.getUserId());
+        } catch (Exception e) {
+            log.warn("Failed to send cart event {} for user {}: {}",
+                    event.getEventType(), event.getUserId(), e.getMessage());
+        }
+    }
+}

--- a/src/main/java/com/vibevault/cartservice/services/CartServiceImpl.java
+++ b/src/main/java/com/vibevault/cartservice/services/CartServiceImpl.java
@@ -23,6 +23,7 @@ public class CartServiceImpl implements CartService {
 
     private final CartRepository cartRepository;
     private final ProductValidationService productValidationService;
+    private final CartEventProducer cartEventProducer;
 
     @Override
     public Cart getCart(String userId) {
@@ -60,7 +61,9 @@ public class CartServiceImpl implements CartService {
             cart.getItems().add(newItem);
         }
 
-        return cartRepository.save(cart);
+        Cart saved = cartRepository.save(cart);
+        cartEventProducer.sendItemAdded(userId, resolvedProductId, quantity);
+        return saved;
     }
 
     @Override
@@ -82,7 +85,9 @@ public class CartServiceImpl implements CartService {
                 .orElseThrow(() -> new CartItemNotFoundException("Product " + productId + " not found in cart"));
 
         item.setQuantity(quantity);
-        return cartRepository.save(cart);
+        Cart saved = cartRepository.save(cart);
+        cartEventProducer.sendItemAdded(userId, productId, quantity);
+        return saved;
     }
 
     @Override
@@ -95,7 +100,9 @@ public class CartServiceImpl implements CartService {
             throw new CartItemNotFoundException("Product " + productId + " not found in cart");
         }
 
-        return cartRepository.save(cart);
+        Cart saved = cartRepository.save(cart);
+        cartEventProducer.sendItemRemoved(userId, productId);
+        return saved;
     }
 
     @Override
@@ -104,7 +111,9 @@ public class CartServiceImpl implements CartService {
                 .orElseThrow(() -> new CartNotFoundException("Cart not found for user: " + userId));
 
         cart.getItems().clear();
-        return cartRepository.save(cart);
+        Cart saved = cartRepository.save(cart);
+        cartEventProducer.sendCartCleared(userId);
+        return saved;
     }
 
     @Override
@@ -116,6 +125,7 @@ public class CartServiceImpl implements CartService {
             throw new EmptyCartException("Cart is empty, cannot checkout");
         }
 
+        cartEventProducer.sendCheckoutInitiated(userId, cart.getItems());
         log.info("Checkout initiated for user: {} with {} items", userId, cart.getTotalItems());
         return cart;
     }

--- a/src/main/java/com/vibevault/cartservice/services/CartServiceImpl.java
+++ b/src/main/java/com/vibevault/cartservice/services/CartServiceImpl.java
@@ -86,7 +86,7 @@ public class CartServiceImpl implements CartService {
 
         item.setQuantity(quantity);
         Cart saved = cartRepository.save(cart);
-        cartEventProducer.sendItemAdded(userId, productId, quantity);
+        cartEventProducer.sendItemUpdated(userId, productId, quantity);
         return saved;
     }
 


### PR DESCRIPTION
## Summary
- Add Kafka event producer for cart operations (fire-and-forget pattern)
- Integrate into CartServiceImpl — events produced after each cart mutation

## Kafka Events

| Event | Trigger | Payload |
|-------|---------|---------|
| `ITEM_ADDED` | Product added or quantity updated | userId, productId, quantity |
| `ITEM_REMOVED` | Product removed from cart | userId, productId |
| `CART_CLEARED` | All items removed | userId |
| `CHECKOUT_INITIATED` | User initiates checkout | userId, full cart items snapshot |

## Design
- Topic: `cart-events`
- Key: `userId` (ensures ordering per user)
- Fire-and-forget: cart operation succeeds even if Kafka is down (failure logged as warning)
- `CHECKOUT_INITIATED` includes full cart snapshot for downstream Order Service consumption

## Files
| Path | Purpose |
|------|---------|
| `events/CartEventType.java` | Event type enum |
| `events/CartEvent.java` | Kafka event payload model |
| `constants/KafkaTopics.java` | Topic name constant |
| `services/CartEventProducer.java` | Kafka producer with error handling |
| `services/CartServiceImpl.java` | Updated to produce events |

Fixes #4