### PR TITLE
Auto-sync MongoDB credentials to AWS Secrets Manager in deploy workflow

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -77,13 +77,23 @@ jobs:
         run: aws eks update-kubeconfig --name ${{ env.EKS_CLUSTER_NAME }} --region ${{ env.AWS_REGION }}
 
       - name: Sync MongoDB credentials to AWS Secrets Manager
+        env:
+          MONGODB_URI: ${{ secrets.MONGODB_URI }}
         run: |
-          aws secretsmanager put-secret-value \
-            --secret-id "vibevault/dev/cartservice/mongo-credentials" \
-            --secret-string "{\"connectionString\":\"${{ secrets.MONGODB_URI }}\"}" 2>/dev/null \
-          || aws secretsmanager create-secret \
-            --name "vibevault/dev/cartservice/mongo-credentials" \
-            --secret-string "{\"connectionString\":\"${{ secrets.MONGODB_URI }}\"}"
+          SECRET_NAME="vibevault/dev/cartservice/mongo-credentials"
+          SECRET_VALUE=$(jq -n --arg cs "$MONGODB_URI" '{connectionString: $cs}')
+
+          if aws secretsmanager describe-secret --secret-id "$SECRET_NAME" > /dev/null 2>&1; then
+            aws secretsmanager put-secret-value \
+              --secret-id "$SECRET_NAME" \
+              --secret-string "$SECRET_VALUE"
+            echo "Secret updated"
+          else
+            aws secretsmanager create-secret \
+              --name "$SECRET_NAME" \
+              --secret-string "$SECRET_VALUE"
+            echo "Secret created"
+          fi
 
       - name: Deploy with Helm
         run: |


### PR DESCRIPTION
## Summary
Add a step in the deploy workflow to create/update the MongoDB Atlas connection string in AWS Secrets Manager from the GitHub environment secret `MONGODB_URI`.

## Why
ExternalSecret in K8s reads MongoDB credentials from AWS Secrets Manager. Previously this required a manual `aws secretsmanager create-secret` command before first deploy. Now it's automated.

## GitHub Secrets needed (dev environment)
| Secret | Value |
|--------|-------|
| `AWS_ROLE_ARN` | IAM role for GitHub Actions |
| `MONGODB_URI` | MongoDB Atlas connection string |

## How it works
1. Deploy workflow runs `put-secret-value` to update existing secret
2. If secret doesn't exist, falls back to `create-secret`
3. ExternalSecret in K8s syncs from Secrets Manager → K8s Secret → pod env var